### PR TITLE
Fix right edge drag to bottom align secondary view

### DIFF
--- a/ItemDecor.kt
+++ b/ItemDecor.kt
@@ -136,7 +136,7 @@ class ItemDecor : ConstraintLayout {
         // Apply any offset for SAME_LEVEL mode
         if (mMode == MODE_SAME_LEVEL && mSecondaryView != null) {
             when (mDragEdge) {
-                DRAG_EDGE_LEFT -> mSecondaryView!!.offsetLeftAndRight(-mSecondaryView!!.width)
+                DRAG_EDGE_LEFT -> mSecondaryView!!.offsetLeftAndRight(mSecondaryView!!.width)
                 DRAG_EDGE_RIGHT -> mSecondaryView!!.offsetLeftAndRight(mSecondaryView!!.width)
             }
             // Update rects after offset
@@ -220,7 +220,7 @@ class ItemDecor : ConstraintLayout {
 
     private val mainOpenLeft: Int
         get() = when (mDragEdge) {
-            DRAG_EDGE_LEFT -> mRectMainClose.left + (mSecondaryView?.width ?: 0)
+            DRAG_EDGE_LEFT -> mRectMainClose.left - (mSecondaryView?.width ?: 0)
             DRAG_EDGE_RIGHT -> mRectMainClose.left - (mSecondaryView?.width ?: 0)
             else -> 0
         }
@@ -233,7 +233,10 @@ class ItemDecor : ConstraintLayout {
             }
         }
     private val secOpenLeft: Int
-        get() = mRectSecClose.left
+        get() = when (mDragEdge) {
+            DRAG_EDGE_LEFT -> mRectMainClose.right
+            else -> mRectSecClose.left
+        }
     private val secOpenTop: Int
         get() = mRectSecClose.top
 
@@ -379,7 +382,7 @@ class ItemDecor : ConstraintLayout {
         private get() {
             if (mSecondaryView == null) return 0
             return if (mDragEdge == DRAG_EDGE_LEFT) {
-                mRectMainClose.left + mSecondaryView!!.width / 2
+                mRectMainClose.left - mSecondaryView!!.width / 2
             } else {
                 mRectMainClose.right - mSecondaryView!!.width / 2
             }
@@ -396,15 +399,12 @@ class ItemDecor : ConstraintLayout {
             return when (mDragEdge) {
                 DRAG_EDGE_RIGHT -> max(
                     min(left.toDouble(), mRectMainClose.left.toDouble()),
-                    (
-                            mRectMainClose.left - mSecondaryView!!.width
-                            ).toDouble()
+                    (mRectMainClose.left - mSecondaryView!!.width).toDouble()
                 ).toInt()
 
                 DRAG_EDGE_LEFT -> max(
-                    min(left.toDouble(), (mRectMainClose.left + mSecondaryView!!.width).toDouble()),
-                    mRectMainClose.left
-                        .toDouble()
+                    min(left.toDouble(), mRectMainClose.left.toDouble()),
+                    (mRectMainClose.left - mSecondaryView!!.width).toDouble()
                 ).toInt()
 
                 else -> child.left
@@ -430,11 +430,11 @@ class ItemDecor : ConstraintLayout {
                 }
 
                 DRAG_EDGE_LEFT -> if (velRightExceeded) {
-                    open(true)
-                } else if (velLeftExceeded) {
                     close(true)
+                } else if (velLeftExceeded) {
+                    open(true)
                 } else {
-                    if (mMainView!!.left < pivotHorizontal) {
+                    if (mMainView!!.left > pivotHorizontal) {
                         close(true)
                     } else {
                         open(true)


### PR DESCRIPTION
Fixes `DRAG_EDGE_LEFT` swipe behavior to correctly bound the main view when revealing the secondary view on the right.

The original implementation of `DRAG_EDGE_LEFT` caused the main view to "vanish" when swiped from right to left. This PR reconfigures `DRAG_EDGE_LEFT` to enable a "swipe left to reveal right" action, ensuring the main view is properly clamped and the secondary view is correctly positioned when revealed.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fcbf702-b3b4-4e51-9007-c18b83d47f2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fcbf702-b3b4-4e51-9007-c18b83d47f2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>